### PR TITLE
Use Blob fallback for Firefox support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,11 +1,26 @@
 #!/usr/bin/env node
 
 var fs = require('fs')
+var parseArgs = require('minimist')
 
 var src = fs.readFileSync(__dirname + '/worker.js', 'utf-8')
+var argv = parseArgs(process.argv)
 
-if (process.argv[2]) {
+// Prefix as argument
+if (argv['_'][2]) { 
   src = src.replace('/browser-server/', process.argv[2])
 }
+
+// --prefix
+if (argv['prefix']) { 
+  src = src.replace('/browser-server/', argv['prefix'])
+}
+
+// --exclude
+var exclude = argv['exclude'] || []
+if (!(exclude instanceof Array)) {
+  exclude = [exclude]
+}
+src = src.replace('{{exclude}}', JSON.stringify(exclude))
 
 process.stdout.write(src)

--- a/index.js
+++ b/index.js
@@ -105,6 +105,13 @@ BrowserServer.prototype._start = function () {
   navigator.serviceWorker.register('/worker.js').then(function () {
     return navigator.serviceWorker.ready
   }).then(function (reg) {
-    self.emit('ready')
+    if (navigator.serviceWorker.controller) {
+      self.emit('ready')
+    } else {
+      var listener = navigator.serviceWorker.addEventListener('controllerchange', () => {
+        navigator.serviceWorker.removeEventListener('controllerchange', listener)
+        self.emit('ready')
+      })
+    }
   })
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "http-status": "^1.0.1",
     "inherits": "^2.0.3",
+    "minimist": "^1.2.0",
     "readable-stream": "^2.2.9"
   },
   "devDependencies": {

--- a/worker.js
+++ b/worker.js
@@ -1,5 +1,6 @@
 var streams = []
 var prefix = '/browser-server/'
+var exclude = {{exclude}}
 
 self.addEventListener('message', function (e) {
   if (e.data.id === -1 && e.data.prefix) {
@@ -15,6 +16,9 @@ self.addEventListener('message', function (e) {
 self.addEventListener('fetch', function (e) {
   var path = '/' + e.request.url.split('/').slice(3).join('/')
   if (path.indexOf(prefix) !== 0) return
+  if (exclude.some(function (ex) {
+    return path.indexOf(ex) === 0
+  })) return
 
   var headers = {}
 

--- a/worker.js
+++ b/worker.js
@@ -3,7 +3,7 @@ var prefix = '/browser-server/'
 var exclude = {{exclude}}
 
 function PseudoReadableStream (source) {
-  if (false && 'ReadableStream' in this) {
+  if ('ReadableStream' in self) {
     this._realObject = new ReadableStream(source)
   } else {
     var parts = []

--- a/worker.js
+++ b/worker.js
@@ -2,6 +2,35 @@ var streams = []
 var prefix = '/browser-server/'
 var exclude = {{exclude}}
 
+function PseudoReadableStream (source) {
+  if (false && 'ReadableStream' in this) {
+    this._realObject = new ReadableStream(source)
+  } else {
+    var parts = []
+    var controller = {
+      enqueue: (data) => {
+        parts.push(data)
+        source.pull(controller)
+      },
+      close: () => {
+        this._realObject = new Blob(parts)
+        if (this._callback) {
+          this._callback(this._realObject)
+        }
+      }
+    }
+    source.pull(controller)
+  }
+
+  this.getRealObject = (cb) => {
+    if (this._realObject) {
+      cb(this._realObject)
+    } else {
+      this._callback = cb
+    }
+  }
+}
+
 self.addEventListener('message', function (e) {
   if (e.data.id === -1 && e.data.prefix) {
     prefix = e.data.prefix
@@ -50,7 +79,7 @@ self.addEventListener('fetch', function (e) {
           }
 
           req.started = true
-          rs = new ReadableStream({
+          rs = new PseudoReadableStream({
             pull: function (c) {
               if (pulling) return
               pulling = true
@@ -65,7 +94,9 @@ self.addEventListener('fetch', function (e) {
             }
           })
 
-          resolve(new Response(rs, {status: data.status, headers: data.headers, statusText: data.statusText}))
+          rs.getRealObject((realObject) => {
+            resolve(new Response(realObject, {status: data.status, headers: data.headers, statusText: data.statusText}))
+          })
         },
         ondata: function (data) {
           pulling = false


### PR DESCRIPTION
Falls back to waiting until response is completed and making a Blob since Firefox doesn't support the ReadableStream constructor (or streaming Response objects at all!).

Doesn't affect Chrome or browsers that implement ReadableStream.